### PR TITLE
corrected, added and changed some links

### DIFF
--- a/algorithms-and-data-structures.md
+++ b/algorithms-and-data-structures.md
@@ -2,6 +2,6 @@
 
 - [x] 👨‍🏫 [**Algorithms Part I**](https://www.coursera.org/learn/algorithms-part1) (R Sedgewick, K Wayne)
 - [x] 👨‍🏫 [**Algorithms Part II**](https://www.coursera.org/learn/algorithms-part2) (R Sedgewick, K Wayne)
-- [ ] 📖 [**Introduction to Algorithms**](https://mitpress.mit.edu/books/introduction-algorithms-third-edition) (TH Cormen, CE Leiserson, RL Rivest, C Stein 2009) _"CLRS"_
+- [ ] 📖 [**Introduction to Algorithms**](https://mitpress.mit.edu/books/introduction-algorithms-fourth-edition) (TH Cormen, CE Leiserson, RL Rivest, C Stein 2009) _"CLRS"_
 - [ ] 📖 [**The Art of Computer Programming**](https://www-cs-faculty.stanford.edu/~knuth/taocp.html) (DE Knuth 1968)
 - [ ] 📖 [The Algorithm Design Manual](https://www.amazon.com/Algorithm-Design-Manual-Steven-Skiena/dp/1848000693/?pldnSite=1) (SS Skiena 2011)

--- a/languages-and-compilers.md
+++ b/languages-and-compilers.md
@@ -2,13 +2,14 @@
 
 ## Compilers
 
-- [ ] 🎥 [**Compilers**](https://lagunita.stanford.edu/courses/Engineering/Compilers/Fall2014/about) (A Aiken 2014)
+- [ ] 🎥 [**Compilers**](http://openclassroom.stanford.edu/MainFolder/CoursePage.php?course=Compilers) (A Aiken 2014)
 - [ ] 📖 [**Compiler Construction**](https://c9x.me/compile/bib/wirthcc.pdf) (N Wirth 2005)
 - [ ] 📖 [**Compilers: Principles, Techniques, and Tools**](https://suif.stanford.edu/dragonbook/) (AV Aho, MS Lam, R Sethi, JD Ullman 2006)
 - [ ] 📖 [**Engineering a Compiler**](https://www.elsevier.com/books/engineering-a-compiler/cooper/978-0-12-088478-0) (K Cooper, L Torczon 2011)
 - [ ] 📖 [**Structure and Interpretation of Computer Programs**](https://mitpress.mit.edu/sites/default/files/sicp/index.html) (H Abelson, GJ Sussman 1984) _The Wizard Book_
 - [ ] 📄 [A New C Compiler](https://c9x.me/compile/bib/new-c.pdf) (K Thompson 1990)
 - [ ] 📄 [Linear Scan Register Allocation](https://c9x.me/compile/bib/linearscan.pdf)  (M Poletto, V Sarkar 1999)
+- [ ]  📄 [Crafting interpreters](https://craftinginterpreters.com/) (Robert Nystrom)
 
 ## Parsers
 

--- a/operating-systems.md
+++ b/operating-systems.md
@@ -1,5 +1,5 @@
 # Operating Systems
 
-- [x] 📖 [**Modern Operating Systems**](https://www.amazon.com/Concrete-Mathematics-Foundation-Computer-Science/dp/0201558025) (AS Tanenbaum, H Bos 2014)
-- [x] 📖 [Linux Kernel Development](https://www.amazon.com/Data-Reality-Perspective-Perceiving-Information/dp/1935504215) (R Love 2010)
+- [x] 📖 [**Modern Operating Systems**](https://www.amazon.com/Modern-Operating-Systems-Andrew-Tanenbaum/dp/013359162X) (AS Tanenbaum, H Bos 2014)
+- [x] 📖 [Linux Kernel Development](https://www.amazon.in/Linux-Kernel-Development-Developers-Library/dp/0672329468) (R Love 2010)
 - [ ] 🛠 [Writing an OS in Rust](https://os.phil-opp.com) (P Oppermann 2019)


### PR DESCRIPTION
1. I found some links were not pointing at the correct URL, changed them.
2. Added **crafting interpreters** by _Robert Nystrom_ under compiler section.
3. Also found two links in _Mathematics.md_, where content is not available anymore.They are listed below.

- Introduction to Discrete Mathematics for Computer Science(AS Kulikov, M Levin, V Podolskii)
- introduction to Linear Algebra(G Strang 2010)